### PR TITLE
update for py3.7+; add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.10
+
+WORKDIR /foodmapr
+
+# cache the requirements before the foodmapr install
+COPY requirements.txt /foodmapr
+
+RUN pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+# download and cache nltk data
+RUN mkdir /nltk_data \
+    && python -m nltk.downloader -d /nltk_data/ punkt stopwords
+
+ENV USER_NLTK_DATA=/nltk_data
+
+COPY . /foodmapr
+
+RUN pip install .
+
+ENTRYPOINT [ "foodmapr" ]

--- a/README.md
+++ b/README.md
@@ -112,3 +112,28 @@ What are the differences:
    }
    ```
 
+## Docker
+
+Foodmapr can be easily be run in a Docker container
+1. Prepare the `input.csv` and `config_foodon.json` as above in
+[Usage](#Usage)
+
+2. After cloning the respository:
+```bash
+cd /path/to/foodmapr
+```
+
+3. Build the container:
+```bash
+docker build . -t foodmapr:latest
+```
+
+4. Run foodmapr, taking care to mount your volume inside the container:  
+```bash
+docker run \
+  -v /path/to/local/data-config:/run-data \
+  foodmapr:latest \
+    /run-data/input.csv \
+    -c /run-data/config_foodon.json \
+    -o /run-data/output.json
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-nltk==3.6.2
-inflection==0.5.1
-rdflib==5.0.0
+inflection~=0.5
+nltk~=3.7
+python-dateutil~=2.8
+rdflib~=6.1

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,10 @@ License :: OSI Approved :: GNU General Public License (GPL)
 Intended Audience :: Science/Research
 Topic :: Scientific/Engineering
 Topic :: Scientific/Engineering :: Bio-Informatics
-Programming Language :: Python :: 2.7
-Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Operating System :: POSIX :: Linux
 """.strip().split('\n')
 
@@ -25,11 +27,12 @@ setup(name='foodmapr',
       license='GPL-3.0',
       classifiers=classifiers,
       install_requires=[
-          'nltk==3.6.2',
-          'inflection==0.5.1',
-          'rdflib==5.0.0',
+          'inflection~=0.5',
+          'nltk~=3.7',
+          'python-dateutil~=2.8',
+          'rdflib~=6.1',
       ],
-      python_requires='>=3.5, <3.9',
+      python_requires='>=3.7, <3.11',
       test_suite='nose.collector',
       tests_require=['nose'],
       packages=find_packages(),


### PR DESCRIPTION
@johardi, after trying `foodmapr` as-is, I ran into a couple issues that I described in #1 

This PR addresses those by
1. Adding the missing dependency
2. Updating the required packages to newer versions
3. Updating the supported Python versions for the current Python lifecycle and match the updated dependencies

I've also added a Dockerfile and some documentation to support it.

I've tested with FOODB and FSANZ data in 3.7, 3.8, 3.9, and 3.10, as well as with the 3.10 Docker image, and it seems to work.

There's only one thing that gives me hesitation in these changes: I'm not sure which Python version the SPOKE team is using internally. If it's <3.7, that could be problematic if they needed to re-clone and rebuild.